### PR TITLE
dont delete yaml comments and an update to template functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "8base-cli",
-  "version": "0.0.94",
+  "version": "0.0.95",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1,3 +1,4 @@
+import * as YAML from 'js-yaml';
 import * as path from 'path';
 import 'isomorphic-fetch';
 import * as request from 'request';
@@ -13,6 +14,11 @@ import { translations, Translations } from './translations';
 
 const MemoryStream = require('memorystream');
 const streamToBuffer = require('stream-to-buffer');
+
+/* Yaml Parser consts */
+const LINES_DELIMITER = '\n';
+const COMMENT_TOKEN = '$comment';
+const MIDDLE_LINE_COMMENT_TOKEN = '$MLcomment';
 
 type workspace = { name: string; id: string };
 
@@ -183,5 +189,50 @@ export namespace Utils {
         handler: CommandController.wrapHandler(cmd.handler, translations),
       };
     }
+  };
+
+  /* Parses yaml string to JSON while preserving comments */
+  export const yamlStringToJson = (str: string): Object => {
+    const lines = str.split(LINES_DELIMITER);
+    const middle_of_line_comment = /([^\#]+)(\#\s?)(.*)/;
+    const start_of_line_comment = /^([\s]*)(\#\s?)(-?\s?)(.*)/;
+
+    const strWithComments = lines
+      .map((line, index) => {
+        if (line.match(start_of_line_comment)) {
+          return line.replace(start_of_line_comment, `$1$3${COMMENT_TOKEN}${index}: "$4"`);
+        } else if (line.match(middle_of_line_comment)) {
+          return line.replace(middle_of_line_comment, `$1${MIDDLE_LINE_COMMENT_TOKEN} "$3"`);
+        } else {
+          return line;
+        }
+      })
+      .join(LINES_DELIMITER);
+
+    return YAML.safeLoad(strWithComments, { json: true });
+  };
+
+  /* Creates yaml string from JSON while placing comments */
+  export const yamlJsonToString = (jsonObject: Object): string => {
+    const yamlAsString = YAML.safeDump(jsonObject, { indent: 2 });
+
+    /* Catch middle of line comments */
+    const MIDDLE_LINE_PATTERN = `(\\${MIDDLE_LINE_COMMENT_TOKEN})( ")(.*)(")`;
+    const middleLineRegex = new RegExp(MIDDLE_LINE_PATTERN, 'g');
+
+    const COMMENT_KEY_VALUE_PATTERN = `(\\${COMMENT_TOKEN}.*:)( ')(.*)(')`;
+    const commentKeyValueRegex = new RegExp(COMMENT_KEY_VALUE_PATTERN, 'g');
+
+    const SWITCH_SIGNS_PATTERN = `(- )?(\\${COMMENT_TOKEN}\\d*)(: )`;
+    const switchSignsRegex = new RegExp(SWITCH_SIGNS_PATTERN, 'g');
+
+    const COMMENT_TOKEN_TO_SIGN = `\\${COMMENT_TOKEN}\\d*`;
+    const tokenToSignRegex = new RegExp(COMMENT_TOKEN_TO_SIGN, 'g');
+
+    return yamlAsString
+      .replace(commentKeyValueRegex, '$1 $3')
+      .replace(middleLineRegex, '# $3')
+      .replace(switchSignsRegex, '$2 $1')
+      .replace(tokenToSignRegex, '#');
   };
 }

--- a/src/engine/commands/generate/commands/scaffold.ts
+++ b/src/engine/commands/generate/commands/scaffold.ts
@@ -1,6 +1,7 @@
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
-import * as yaml from 'js-yaml';
+
+import { Utils } from '../../../../common/utils';
 import { Context } from '../../../../common/context';
 import { translations } from '../../../../common/translations';
 import { Interactive } from '../../../../common/interactive';
@@ -104,8 +105,9 @@ export default {
     context.spinner.stop();
 
     let eightBaseConfig: EightBaseConfig;
+
     try {
-      eightBaseConfig = <any>yaml.safeLoad(await fs.readFile('.8base.yml', 'utf8'));
+      eightBaseConfig = <any>Utils.yamlStringToJson(fs.readFileSync('.8base.yml', 'utf8'));
     } catch (err) {
       if (err.code === 'ENOENT') {
         throw new Error(translations.i18n.t('generate_scaffold_project_file_error', { projectFileName: '.8base.yml' }));

--- a/src/engine/controllers/projectController.ts
+++ b/src/engine/controllers/projectController.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as yaml from 'js-yaml';
 import * as ejs from 'ejs';
 import * as mkdirp from 'mkdirp';
 import * as changeCase from 'change-case';
@@ -20,6 +19,7 @@ import {
 } from '../../interfaces/Extensions';
 import { ProjectDefinition } from '../../interfaces/Project';
 import { Context } from '../../common/context';
+import { Utils } from '../../common/utils';
 
 type FunctionDeclarationOptions = {
   operation?: string;
@@ -192,7 +192,7 @@ export class ProjectController {
     }
 
     try {
-      return yaml.safeLoad(fs.readFileSync(pathToYmlConfig, 'utf8'));
+      return Utils.yamlStringToJson(fs.readFileSync(pathToYmlConfig, 'utf8'));
     } catch (ex) {
       throw new InvalidConfiguration(StaticConfig.serviceConfigFileName, ex.message);
     }
@@ -201,7 +201,7 @@ export class ProjectController {
   private static saveConfigFile(context: Context, config: Object, projectPath?: string, silent?: boolean): any {
     const pathToYmlConfig = projectPath ? path.join(projectPath, '8base.yml') : StaticConfig.serviceConfigFileName;
 
-    fs.writeFileSync(pathToYmlConfig, yaml.safeDump(config));
+    fs.writeFileSync(pathToYmlConfig, Utils.yamlJsonToString(config));
 
     if (!silent) {
       context.logger.info(
@@ -538,7 +538,6 @@ const processTemplate = (
     }
 
     const data = fs.readFileSync(path.resolve(templatePath, file));
-
     const content = ejs.compile(data.toString())({
       ...options,
       changeCase,
@@ -547,7 +546,6 @@ const processTemplate = (
     let fileName = file.replace(/\.ejs$/, '');
 
     fileName = fileName.replace('mockName', _.get(options, 'mockName'));
-
     fs.writeFileSync(path.resolve(dirPath, fileName), content);
 
     if (!silent) {

--- a/templates/functions/resolver/handler.js.ejs
+++ b/templates/functions/resolver/handler.js.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to this function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 module.exports = async (event, ctx) => {

--- a/templates/functions/resolver/handler.ts.ejs
+++ b/templates/functions/resolver/handler.ts.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to this function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 type ResolverResult = {

--- a/templates/functions/task/handler.js.ejs
+++ b/templates/functions/task/handler.js.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to the function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/tasks/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 module.exports = async (event, ctx) => {

--- a/templates/functions/task/handler.ts.ejs
+++ b/templates/functions/task/handler.ts.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to the function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/tasks/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 type TaskResult = {

--- a/templates/functions/trigger/handler.js.ejs
+++ b/templates/functions/trigger/handler.js.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to the function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/triggers/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 module.exports = async (event, ctx) => {

--- a/templates/functions/trigger/handler.ts.ejs
+++ b/templates/functions/trigger/handler.ts.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to the function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/triggers/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 type TriggerResult = {

--- a/templates/functions/webhook/handler.js.ejs
+++ b/templates/functions/webhook/handler.js.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to the function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/webhooks/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 module.exports = async (event, ctx) => {

--- a/templates/functions/webhook/handler.ts.ejs
+++ b/templates/functions/webhook/handler.ts.ejs
@@ -15,8 +15,17 @@
  * Data that is sent to the function can be accessed on the event argument at:
  *  event.data[KEY_NAME]
  *
- * To invoke this function locally, run:
- *  8base invoke-local <%= functionName %> -p src/webhooks/<%= functionName %>/mocks/request.json
+ * There are two ways to invoke this function locally:
+ *  
+ *  (1) Explicit file mock file path using '-p' flag:
+ *    8base invoke-local <%= functionName %> -p src/resolvers/<%= functionName %>/mocks/request.json
+ *
+ *  (2) Default mock file location using -m flag:
+ *    8base invoke-local <%= functionName %> -m request
+ *
+ *  Add new mocks to this function to test different input arguments. Mocks can easily be generated
+ *  the following generator command:
+ *    8base generate mock <%= functionName %> -m [MOCK_FILE_NAME]
  */
 
 type WebhookResult = {


### PR DESCRIPTION
This pull request allows developers to add comments to their 8base.yml file and not have them deleted when a generator is used or the file is updated.

There are also several template updates.