### PR TITLE
fix 'Cannot convert undefined or null to object'

### DIFF
--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -284,7 +284,9 @@ export class Context {
         ? customAuthorization
         : this.storage.getValue(StorageParameters.idToken);
     this.logger.debug(this.i18n.t('debug:set_id_token'));
-    client.setIdToken(authToken || '');
+    if (authToken) {
+      client.setIdToken(authToken);
+    }
 
     if (customAuthorization === REQUEST_HEADER_NOT_SET && !this.user.isAuthorized()) {
       throw new Error(this.i18n.t('logout_error'));


### PR DESCRIPTION
'' is false and in this case gqlClient trying to delete non existing this.gqlc.options.headers.Authorization, we should set token only if it is non-empty string.