### PR TITLE
[cli] Can't use `8base init` without workspaces

### DIFF
--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -221,7 +221,7 @@ export class Context {
     const workspaces = await this.workspaceList();
 
     if (_.isEmpty(workspaces) || !_.isArray(workspaces)) {
-      throw new Error(this.i18n.t('logout_error'));
+      throw new Error(this.i18n.t('empty_workspaces'));
     }
 
     return workspaces;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -27,6 +27,7 @@ export default {
       "The current folder isn't an 8base project, so there is nothing to configure!\n\nTry re-runing this command from the root of an existing 8base project or use '8base init' to create a new project.",
     workspace_not_found:
       'Workspace not found. Try to run `8base configure` to select existing workspace for this project.',
+    empty_workspaces: 'No workspaces found. Try to create a new workspace first',
 
     /**
      * Project info related messages


### PR DESCRIPTION
- Update message error when the user have empty workspaces