### PR TITLE
[Update] Change the pipeline name

### DIFF
--- a/.github/workflows/publish_beta.yml
+++ b/.github/workflows/publish_beta.yml
@@ -1,4 +1,4 @@
-name: publish
+name: publish_beta
 
 on:
   release:


### PR DESCRIPTION
By default, all the releases start publishing a beta. the release is completely manual